### PR TITLE
Bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Then, just add the dependency:
 
 ```groovy
 dependencies {
-    implementation 'com.github.GeotecINIT:BackgroundSensors:1.0.0'
+    implementation 'com.github.GeotecINIT:BackgroundSensors:1.0.1'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ dependencies {
 ## Requirements
 The library has the following requirements:
 
-- A device running Android 4.2 (API level 17) or higher.
+- A device running Android 5.0 (API level 21) or higher.
 - _(Optional)_ For apps targeting an API level 31 or higher and willing to collect data from the sensors
 at a sampling rate higher than 200Hz, the following permission must be added:
   

--- a/backgroundsensors/build.gradle
+++ b/backgroundsensors/build.gradle
@@ -7,7 +7,7 @@ android {
     compileSdk 31
 
     defaultConfig {
-        minSdk 17
+        minSdk 21
         targetSdk 31
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/backgroundsensors/build.gradle
+++ b/backgroundsensors/build.gradle
@@ -42,7 +42,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.GeotecINIT'
             artifactId = 'BackgroundSensors'
-            version = '1.0.0'
+            version = '1.0.1'
 
             afterEvaluate {
                 from components.release
@@ -80,7 +80,7 @@ publishing {
         debug(MavenPublication) {
             groupId = 'com.github.GeotecINIT'
             artifactId = 'BackgroundSensors'
-            version = '1.0.0-debug'
+            version = '1.0.1-debug'
 
             afterEvaluate {
                 from components.debug

--- a/backgroundsensors/src/main/java/es/uji/geotec/backgroundsensors/time/TimeProvider.java
+++ b/backgroundsensors/src/main/java/es/uji/geotec/backgroundsensors/time/TimeProvider.java
@@ -8,5 +8,5 @@ public abstract class TimeProvider {
         return getTimestamp() + (elapsedNanos - SystemClock.elapsedRealtimeNanos()) / 1000000L;
     }
 
-    abstract long getTimestamp();
+    public abstract long getTimestamp();
 }


### PR DESCRIPTION
This PR solves a couple of spotted bugs:

- `TimeProvider` method `getTimestamp` was not public, so it could not be accessed. Now, it has made public.
- After lowering the `minSdk` to 17, an application using the library was not able to override the icon of the recording service (`ic_sensor_service`). To solve the issue, the `minSdk` has been set to 21.