### PR TITLE
SensorRecordingService extension with ntp time provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To install the library you have to add the dependency in your `build.gradle`:
 
 ```groovy
 dependencies {
-    implementation 'io.github.geotecinit:background-sensors:1.0.0'
+    implementation 'io.github.geotecinit:background-sensors:1.1.0'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ The usage of the library is pretty straightforward. The sensors are defined in t
 the [`SensorManager`](#sensormanager) can be used to know which ones of them are available in the device. 
 
 To manage the data collection, an instance of the [`ServiceManager`](#servicemanager) must be created injecting 
-the `BaseSensorRecordingService` (i.e., the service for collecting data from the `BaseSensor`). Then, 
-the instance can be used to start and stop the data collection.
+a `SensorRecordingService`. We offer two implementations of this service: the `BaseSensorRecordingService` and
+the `NTPSyncedSensorRecordingService` (syncs the system clock with an NTP server to label the collected samples with the most accurate timestamp). Then, 
+the `ServiceManager` instance can be used to start and stop the data collection.
 
 To start the data collection, a [`CollectionConfiguration`](#collectionconfiguration) must be provided, indicating the type of sensor
 to collect data from, the sensor delay (i.e., time between samples) and the batch size 
@@ -61,6 +62,8 @@ public class Demo extends Activity {
         
         sensorManager = new SensorManager(context);
         serviceManager = new ServiceManager(this, BaseSensorRecordingService.class);
+        // or...
+        serviceManager = new ServiceManager(this, NTPSyncedSensorRecordingService.class);
         
         // ...
     }

--- a/backgroundsensors/build.gradle
+++ b/backgroundsensors/build.gradle
@@ -43,7 +43,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'io.github.geotecinit'
             artifactId = 'background-sensors'
-            version = '1.0.1'
+            version = '1.1.0'
 
             afterEvaluate {
                 from components.release
@@ -81,7 +81,7 @@ publishing {
         debug(MavenPublication) {
             groupId = 'io.github.geotecinit'
             artifactId = 'background-sensors'
-            version = '1.0.1-debug'
+            version = '1.1.0-debug'
 
             afterEvaluate {
                 from components.debug

--- a/backgroundsensors/src/main/AndroidManifest.xml
+++ b/backgroundsensors/src/main/AndroidManifest.xml
@@ -2,10 +2,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="es.uji.geotec.backgroundsensors">
 
+    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application>
         <service android:name=".service.BaseSensorRecordingService" android:exported="true" />
+        <service android:name=".service.NTPSyncedSensorRecordingService" android:exported="true" />
     </application>
 </manifest>

--- a/backgroundsensors/src/main/java/es/uji/geotec/backgroundsensors/service/NTPSyncedSensorRecordingService.java
+++ b/backgroundsensors/src/main/java/es/uji/geotec/backgroundsensors/service/NTPSyncedSensorRecordingService.java
@@ -1,0 +1,33 @@
+package es.uji.geotec.backgroundsensors.service;
+
+import android.util.Log;
+
+import es.uji.geotec.backgroundsensors.collection.BaseCollectorManager;
+import es.uji.geotec.backgroundsensors.collection.CollectorManager;
+import es.uji.geotec.backgroundsensors.time.NTPTimeProvider;
+
+public class NTPSyncedSensorRecordingService extends SensorRecordingService {
+
+    protected NTPTimeProvider ntpTimeProvider;
+    protected boolean ntpSynced;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        ntpTimeProvider = NTPTimeProvider.getInstance();
+        ntpSynced = ntpTimeProvider.isSynced();
+
+        if (!ntpSynced) {
+            ntpSynced = ntpTimeProvider.sync();
+            if (!ntpSynced) {
+                Log.d("SyncedRecordingService", "ntp syncing failed, using system clock");
+            }
+        }
+    }
+
+    @Override
+    public CollectorManager getCollectorManager() {
+        return new BaseCollectorManager(this, NTPTimeProvider.getInstance());
+    }
+}

--- a/backgroundsensors/src/main/java/es/uji/geotec/backgroundsensors/service/SensorRecordingService.java
+++ b/backgroundsensors/src/main/java/es/uji/geotec/backgroundsensors/service/SensorRecordingService.java
@@ -81,6 +81,14 @@ public abstract class SensorRecordingService extends Service {
         super.onDestroy();
     }
 
+    protected void gracefullyStop() {
+        stopForeground(true);
+        if (wakeLock.isHeld()) {
+            wakeLock.release();
+        }
+        stopSelf();
+    }
+
     private void runInForegroundWithNotification() {
         NotificationProvider notificationProvider = new NotificationProvider(this);
 
@@ -118,14 +126,6 @@ public abstract class SensorRecordingService extends Service {
             Log.d(TAG, "no more sensors being recorded");
             gracefullyStop();
         }
-    }
-
-    private void gracefullyStop() {
-        stopForeground(true);
-        if (wakeLock.isHeld()) {
-            wakeLock.release();
-        }
-        stopSelf();
     }
 
     public abstract CollectorManager getCollectorManager();

--- a/backgroundsensors/src/main/java/es/uji/geotec/backgroundsensors/time/NTPTimeProvider.java
+++ b/backgroundsensors/src/main/java/es/uji/geotec/backgroundsensors/time/NTPTimeProvider.java
@@ -1,0 +1,41 @@
+package es.uji.geotec.backgroundsensors.time;
+
+import android.util.Log;
+
+import es.uji.geotec.backgroundsensors.time.ntp.GoodClock;
+
+public class NTPTimeProvider extends TimeProvider {
+
+    private static NTPTimeProvider instance;
+
+    private GoodClock clock;
+    private long lastSyncTimestamp;
+
+    private NTPTimeProvider() {
+        clock = new GoodClock(5, GoodClock.DEFAULT_UPDATE_INTERVAL);
+    }
+
+    public static NTPTimeProvider getInstance() {
+        if (instance == null) {
+            instance = new NTPTimeProvider();
+        }
+        return instance;
+    }
+
+    public boolean sync() {
+        boolean success = clock.singleSync();
+        lastSyncTimestamp = getTimestamp();
+        return success;
+    }
+
+    public boolean isSynced() {
+        long now = getTimestamp();
+
+        return now - lastSyncTimestamp < 60000 && clock.SntpSuceeded;
+    }
+
+    @Override
+    public long getTimestamp() {
+        return clock.SntpSuceeded ? clock.Now() : System.currentTimeMillis();
+    }
+}

--- a/backgroundsensors/src/main/java/es/uji/geotec/backgroundsensors/time/ntp/GoodClock.java
+++ b/backgroundsensors/src/main/java/es/uji/geotec/backgroundsensors/time/ntp/GoodClock.java
@@ -1,0 +1,350 @@
+/*
+Author: Sandeep Singh Sandha
+Email: sandha.iitr@gmail.com
+*/
+
+
+/*
+ * Modified by: Miguel Matey Sanz
+ * Email: matey@uji.es
+ */
+
+
+package es.uji.geotec.backgroundsensors.time.ntp;
+
+import android.os.SystemClock;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+
+public class GoodClock {
+
+    public static int DEFAULT_REQUESTS_PER_NTP_UPDATE = 10;
+    public static long DEFAULT_UPDATE_INTERVAL = 15*60*1000; //Default update every 15  minutes
+
+
+    SntpDsense client = null;
+    String ntpHost = "time.google.com";
+    int timeout = 3000;
+
+
+    public boolean SntpSuceeded;
+    Thread NTP_update;
+    boolean NTP_thread_running=false;
+
+    boolean use_drift_correction =false;
+
+    //stores the drift in the ntp_clockoffset
+    double drift =0.0;
+
+    //these are affected when system time jumps
+    double first_ntp_offset = 0;
+    long first_ntp_monotonic_time=0;
+    long first_ntp_sys_time=0;
+
+    long curr_ntp_offset = 0;
+    long curr_ntp_monotonic_time=0;
+    long curr_ntp_sys_time=0;
+
+    //below numbers are used in the drift computation
+    double total_ntp_offset_run =0.0;
+    double total_ntp_monotonic_time_run =0.0;
+    double total_ntp_offset_change =0.0;
+    double total_ntp_monotonic_time_passed=0.0;
+
+    boolean is_first =true; //stores whether it is a first NTP update
+
+    private long updateInterval;
+
+    /*
+    1) Initializing SntpDsense client
+    2) Initialize SNTP (NTP) has not been done
+     */
+    public GoodClock() {
+        this(DEFAULT_REQUESTS_PER_NTP_UPDATE, DEFAULT_UPDATE_INTERVAL);
+    }//end GoodClock()
+
+    public GoodClock(int requestsPerNTPUpdate, long updateInterval) {
+        this.updateInterval = updateInterval;
+
+        try{
+            client = new SntpDsense(requestsPerNTPUpdate);
+            SntpSuceeded=false;
+            NTP_update=null;
+
+            // period = 10000;//how often to do the NTP update
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+    }
+
+    //start the dsense library
+    /*
+    Create a thread to periodically update the SntpDsense client ntp update function
+     */
+    public void startSync()
+    {
+        try{
+            //start thread only if not running
+            if(NTP_update==null) {
+                NTP_thread_running=true;
+                NTP_update = new Thread(thread_periodic_update_NTP);
+                NTP_update.start();
+
+            }
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+
+
+
+    }//end start
+
+    public boolean singleSync() {
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        Future<Boolean> futureTask = executorService.submit(new SingleSyncFuture(this));
+
+        try {
+            return futureTask.get();
+        } catch (ExecutionException e) {
+            e.printStackTrace();
+        } catch (InterruptedException interruptedException) {
+            interruptedException.printStackTrace();
+        }
+        return false;
+    }
+
+    private boolean futureSync() {
+        SntpSuceeded = this.doSync();
+        return SntpSuceeded;
+    }
+
+    public void stop()
+    {
+        NTP_thread_running=false;
+        Thread moribund = NTP_update;
+        NTP_update = null;
+        moribund.interrupt();
+    }//end stop
+
+    //return currentTimeMillis based on the below logic:
+    /*
+    1) Stores the NTP offset of the system time and updates the offset periodically
+     */
+    public long currentTimeMillis()
+    {
+
+    /*
+    We have to make sure client is not null
+     */
+        if(client==null)
+            return -1;//client not initialized
+
+        long now = -1;
+        try{
+
+            //client.get_ntp_update_sys_time(): last sys time NTP was updated.
+            //SystemClock.elapsedRealtime(): monotonic system elaspsed time since boot.
+            //client.get_ntp_update_monotonic_time(): monotonic system elasped time at instant of NTP offset calcuation.
+            //client.getNtp_clockoffset(): offset of system time with NTP server at time of NTP update
+            long elapsed_time_since_last_ntp = SystemClock.elapsedRealtime() - curr_ntp_monotonic_time;
+            long drift_correction = (long)((drift)*(double)(elapsed_time_since_last_ntp));
+            now = drift_correction+curr_ntp_offset+curr_ntp_sys_time+elapsed_time_since_last_ntp;
+
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+
+        return now;
+    }//end long currentTimeMillis
+
+
+    /*
+   Gives the time now in milliseconds based on corrections
+     */
+    public long Now()
+    {
+
+    /*
+    We have to make sure client is not null
+     */
+        if(client==null)
+            return -1;//client not initialized
+
+        long now = -1;
+        try{
+
+            long elapsed_time_since_last_ntp = SystemClock.elapsedRealtime() - curr_ntp_monotonic_time;
+            long drift_correction = (long)((drift)*(double)(elapsed_time_since_last_ntp));
+            now = drift_correction+curr_ntp_offset+curr_ntp_sys_time+elapsed_time_since_last_ntp;
+
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+
+        return now;
+    }//end long Now
+
+    public long getNtp_clockoffset()
+    {
+        try{
+            return client.getNtp_clockoffset();
+        }
+        catch (Exception e)
+        {
+            return Integer.MAX_VALUE;
+        }
+
+    }
+
+    public double getDrift()
+    {
+        return drift;
+
+    }//end getDrift()
+
+    Runnable thread_periodic_update_NTP = new Runnable() {
+        @Override
+        public void run() {
+            Thread thisThread = Thread.currentThread();
+            while(NTP_update == thisThread) {
+                try {
+
+                    System.out.println("GoodClock Thread is running");
+                    SntpSuceeded = doSync();
+
+                    Thread.sleep(updateInterval);
+
+                } catch (InterruptedException interruptedException) {
+                    System.out.println("GoodClock Thread interrupted");
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+
+                if(!NTP_thread_running)
+                {
+                    break;
+                }
+
+            }//end  while (true)
+        }//end run
+    };
+
+    private boolean doSync() {
+        boolean succeeded = client.requestTime(ntpHost, timeout);
+
+        if (succeeded) {
+            //is this the first update
+            if (is_first) {
+                is_first = false;
+
+
+                curr_ntp_offset = client.getNtp_clockoffset();
+                curr_ntp_monotonic_time = client.get_ntp_update_monotonic_time();
+                curr_ntp_sys_time = client.get_ntp_update_sys_time();
+
+                //these are set during the first time
+                first_ntp_monotonic_time = curr_ntp_monotonic_time;
+                first_ntp_offset = curr_ntp_offset;
+                first_ntp_sys_time = curr_ntp_sys_time;
+
+            } else {
+
+
+                curr_ntp_offset = client.getNtp_clockoffset();
+                curr_ntp_monotonic_time = client.get_ntp_update_monotonic_time();
+                curr_ntp_sys_time = client.get_ntp_update_sys_time();
+
+                //if there was jump in the system time, then the previous
+                //difference in monotonic time will not match with the difference in the system time
+
+                long diff_monotonic = curr_ntp_monotonic_time - first_ntp_monotonic_time;
+                long diff_system = curr_ntp_sys_time - first_ntp_sys_time;
+
+                long jump_system_time = diff_monotonic - diff_system;
+
+                //note this clock difference will be due to the jump in system time due to correction (NTP or Nitz at the system level)
+                //we need to check there was no jump in the system time
+
+                if (Math.abs(jump_system_time) < 10)//there is an insignificant jump of 10 ms or less.
+
+                {
+
+                    total_ntp_offset_run = (curr_ntp_offset - first_ntp_offset);
+                    total_ntp_monotonic_time_run = (curr_ntp_monotonic_time - first_ntp_monotonic_time);
+
+                    double curr_drift = 0.0;
+
+                    if (total_ntp_monotonic_time_run > (10.0 * 60.0 * 1000.0))//if current run > 10 minutes
+                    {
+
+                        curr_drift = (total_ntp_offset_change + total_ntp_offset_run) / (total_ntp_monotonic_time_passed + total_ntp_monotonic_time_run);
+
+                        //System.out.println("Sandeep: curr run"+total_ntp_offset_run+":"+total_ntp_monotonic_time_run);
+                    } else//we only use the value from the previous runs, in case system time is changed
+                    {
+                        curr_drift = (total_ntp_offset_change) / (total_ntp_monotonic_time_passed);
+                    }
+
+
+                    if (curr_drift * (1000.0 * 60.0 * 60.0 * 24.0) > 40) {
+                        drift = curr_drift;
+                    } else
+                        drift = 0.0;
+
+                }
+
+                //we are starting a new offset calcuation after the jump
+                else {
+
+                    total_ntp_offset_change = total_ntp_offset_change + total_ntp_offset_run;
+                    total_ntp_monotonic_time_passed = total_ntp_monotonic_time_passed + total_ntp_monotonic_time_run;
+
+
+                    is_first = true;
+
+                    curr_ntp_offset = client.getNtp_clockoffset();
+                    curr_ntp_monotonic_time = client.get_ntp_update_monotonic_time();
+                    curr_ntp_sys_time = client.get_ntp_update_sys_time();
+
+                    //these are set during the first time
+                    first_ntp_monotonic_time = curr_ntp_monotonic_time;
+                    first_ntp_offset = curr_ntp_offset;
+                    first_ntp_sys_time = curr_ntp_sys_time;
+
+                }
+
+
+            }//end else
+
+        }
+
+        return succeeded;
+    }
+
+    private class SingleSyncFuture implements Callable<Boolean> {
+
+        private GoodClock goodClock;
+
+        public SingleSyncFuture(GoodClock goodClock) {
+            this.goodClock = goodClock;
+        }
+
+        @Override
+        public Boolean call() throws Exception {
+            return this.goodClock.futureSync();
+        }
+    }
+}//end GoodClock

--- a/backgroundsensors/src/main/java/es/uji/geotec/backgroundsensors/time/ntp/SntpDsense.java
+++ b/backgroundsensors/src/main/java/es/uji/geotec/backgroundsensors/time/ntp/SntpDsense.java
@@ -1,0 +1,319 @@
+/*
+ * Original Code from the Android Open Source Project.
+ * Modified By Sandeep Singh Sandha.
+ * Email: sandha.iitr@gmail.com
+ */
+
+/*
+ * Modified by: Miguel Matey Sanz
+ * Email: matey@uji.es
+ */
+
+/*
+SNTP client used for distributed sensing
+Modification to do multiple NTP requests and selection of offset so as to enable less variability
+and more sync accuracy.
+ */
+
+
+package es.uji.geotec.backgroundsensors.time.ntp;
+
+import android.os.SystemClock;
+import android.util.Log;
+
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+
+
+public class SntpDsense {
+    private static final String TAG = "SntpDsense";
+    private static final boolean DBG = true;
+
+    private static final int REFERENCE_TIME_OFFSET = 16;
+    private static final int ORIGINATE_TIME_OFFSET = 24;
+    private static final int RECEIVE_TIME_OFFSET = 32;
+    private static final int TRANSMIT_TIME_OFFSET = 40;
+    private static final int NTP_PACKET_SIZE = 48;
+
+    private static final int NTP_PORT = 123;
+    private static final int NTP_MODE_CLIENT = 3;
+    private static final int NTP_MODE_SERVER = 4;
+    private static final int NTP_MODE_BROADCAST = 5;
+    private static final int NTP_VERSION = 3;
+
+    private static final int NTP_LEAP_NOSYNC = 3;
+    private static final int NTP_STRATUM_DEATH = 0;
+    private static final int NTP_STRATUM_MAX = 15;
+
+    // Number of seconds between Jan 1, 1900 and Jan 1, 1970
+    // 70 years plus 17 leap days
+    private static final long OFFSET_1900_TO_1970 = ((365L * 70L) + 17L) * 24L * 60L * 60L;
+
+
+    private long ntp_update_sys_time; //the systime when NTP update was done
+
+    // value of SystemClock.elapsedRealtime() corresponding to mNtpTime
+    private long ntp_update_monotonic_time;//the monotonic sys time when NTP update was done
+
+    // round trip time in milliseconds
+    private long mRoundTripTime;
+
+    //offset of system clock from ntp clock
+    private long ntp_clockoffset;
+
+    private int requestsPerNTPUpdate;
+
+    public SntpDsense(int requestsPerNTPUpdate) {
+        this.requestsPerNTPUpdate = requestsPerNTPUpdate;
+    }
+
+    private static class InvalidServerReplyException extends Exception {
+        public InvalidServerReplyException(String message) {
+            super(message);
+        }
+    }
+
+    /**
+     * Sends an SNTP request to the given host and processes the response.
+     *
+     * @param host host name of the server.
+     * @param timeout network timeout in milliseconds.
+     * @return true if the transaction was successful.
+     */
+    public boolean requestTime(String host, int timeout) {
+        InetAddress address = null;
+        try {
+            address = InetAddress.getByName(host);
+        } catch (Exception e) {
+            //EventLogTags.writeNtpFailure(host, e.toString());
+            //if (DBG) Log.d(TAG, "request time failed: " + e);
+            return false;
+        }
+        return requestTime(address, NTP_PORT, timeout);
+    }
+
+    public boolean requestTime(InetAddress address, int port, int timeout) {
+
+        int retry = this.requestsPerNTPUpdate;
+
+        ArrayList<Long> array_clockOffset = new ArrayList<Long>();
+
+
+        while(retry>0) {
+            DatagramSocket socket = null;
+
+            try {
+
+                //Thread.sleep(1000);
+
+                socket = new DatagramSocket();
+                socket.setSoTimeout(timeout);
+
+
+                byte[] buffer = new byte[NTP_PACKET_SIZE];
+                DatagramPacket request = new DatagramPacket(buffer, buffer.length, address, port);
+
+                // set mode = 3 (client) and version = 3
+                // mode is in low 3 bits of first byte
+                // version is in bits 3-5 of first byte
+                buffer[0] = NTP_MODE_CLIENT | (NTP_VERSION << 3);
+
+                // get current time and write it to the request packet
+                final long requestTime = System.currentTimeMillis();
+                final long requestTicks = SystemClock.elapsedRealtime();
+                writeTimeStamp(buffer, TRANSMIT_TIME_OFFSET, requestTime);
+
+                socket.send(request);
+
+                // read the response
+                DatagramPacket response = new DatagramPacket(buffer, buffer.length);
+                socket.receive(response);
+                final long responseTicks = SystemClock.elapsedRealtime();
+                final long responseTime = requestTime + (responseTicks - requestTicks);
+
+                // extract the results
+                final byte leap = (byte) ((buffer[0] >> 6) & 0x3);
+                final byte mode = (byte) (buffer[0] & 0x7);
+                final int stratum = (int) (buffer[1] & 0xff);
+                final long originateTime = readTimeStamp(buffer, ORIGINATE_TIME_OFFSET);
+                final long receiveTime = readTimeStamp(buffer, RECEIVE_TIME_OFFSET);
+                final long transmitTime = readTimeStamp(buffer, TRANSMIT_TIME_OFFSET);
+
+                /* do sanity check according to RFC */
+                // TODO: validate originateTime == requestTime.
+                checkValidServerReply(leap, mode, stratum, transmitTime);
+
+                long roundTripTime = responseTicks - requestTicks - (transmitTime - receiveTime);
+
+                long clockOffset = ((receiveTime - originateTime) + (transmitTime - responseTime)) / 2;
+
+                if(roundTripTime<500)//200 ms is the delay based on observation in Android LTE
+                {
+                    array_clockOffset.add(clockOffset);
+                }
+
+
+                if (DBG) {
+                    Log.d(TAG, "round trip: " + roundTripTime + "ms, " +
+                            "clock offset: " + clockOffset + "ms");
+                }
+
+
+                retry--;
+
+            } catch (Exception e) {
+                //EventLogTags.writeNtpFailure(address.toString(), e.toString());
+                if (DBG) Log.d(TAG, "request time failed: " + e);
+                return false;
+            } finally {
+                if (socket != null) {
+                    socket.close();
+                }
+
+            }
+
+
+        }//end while(retry>0)
+
+
+        //there was some query as successfull
+        if(array_clockOffset.size()>0) {
+
+            //sort the clockoffset
+            Collections.sort(array_clockOffset);
+
+
+            //take the median of the offset
+            ntp_clockoffset=  array_clockOffset.get(array_clockOffset.size()/2);
+
+            //at this current system which we calculated the offset
+            ntp_update_sys_time = System.currentTimeMillis();
+
+            //at this instant monotonic system time
+            ntp_update_monotonic_time = SystemClock.elapsedRealtime();;
+
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns the time computed from the NTP transaction.
+     *
+     * @return time value computed from NTP server response.
+     */
+    public long get_ntp_update_sys_time() {
+        return ntp_update_sys_time;
+    }
+
+
+    /*
+    Returns the ntp_clockoffset
+     */
+    public long getNtp_clockoffset()
+    {
+        return ntp_clockoffset;
+    }
+
+    /**
+     * Returns the reference clock value (value of SystemClock.elapsedRealtime())
+     * corresponding to the NTP time.
+     *
+     * @return reference clock corresponding to the NTP time.
+     */
+    public long get_ntp_update_monotonic_time() {
+        return ntp_update_monotonic_time;
+    }
+
+    /**
+     * Returns the round trip time of the NTP transaction
+     *
+     * @return round trip time in milliseconds.
+     */
+    public long getRoundTripTime() {
+        return mRoundTripTime;
+    }
+
+    private static void checkValidServerReply(
+            byte leap, byte mode, int stratum, long transmitTime)
+            throws InvalidServerReplyException {
+        if (leap == NTP_LEAP_NOSYNC) {
+            throw new InvalidServerReplyException("unsynchronized server");
+        }
+        if ((mode != NTP_MODE_SERVER) && (mode != NTP_MODE_BROADCAST)) {
+            throw new InvalidServerReplyException("untrusted mode: " + mode);
+        }
+        if ((stratum == NTP_STRATUM_DEATH) || (stratum > NTP_STRATUM_MAX)) {
+            throw new InvalidServerReplyException("untrusted stratum: " + stratum);
+        }
+        if (transmitTime == 0) {
+            throw new InvalidServerReplyException("zero transmitTime");
+        }
+    }
+
+    /**
+     * Reads an unsigned 32 bit big endian number from the given offset in the buffer.
+     */
+    private long read32(byte[] buffer, int offset) {
+        byte b0 = buffer[offset];
+        byte b1 = buffer[offset+1];
+        byte b2 = buffer[offset+2];
+        byte b3 = buffer[offset+3];
+
+        // convert signed bytes to unsigned values
+        int i0 = ((b0 & 0x80) == 0x80 ? (b0 & 0x7F) + 0x80 : b0);
+        int i1 = ((b1 & 0x80) == 0x80 ? (b1 & 0x7F) + 0x80 : b1);
+        int i2 = ((b2 & 0x80) == 0x80 ? (b2 & 0x7F) + 0x80 : b2);
+        int i3 = ((b3 & 0x80) == 0x80 ? (b3 & 0x7F) + 0x80 : b3);
+
+        return ((long)i0 << 24) + ((long)i1 << 16) + ((long)i2 << 8) + (long)i3;
+    }
+
+    /**
+     * Reads the NTP time stamp at the given offset in the buffer and returns
+     * it as a system time (milliseconds since January 1, 1970).
+     */
+    private long readTimeStamp(byte[] buffer, int offset) {
+        long seconds = read32(buffer, offset);
+        long fraction = read32(buffer, offset + 4);
+        // Special case: zero means zero.
+        if (seconds == 0 && fraction == 0) {
+            return 0;
+        }
+        return ((seconds - OFFSET_1900_TO_1970) * 1000) + ((fraction * 1000L) / 0x100000000L);
+    }
+
+    /**
+     * Writes system time (milliseconds since January 1, 1970) as an NTP time stamp
+     * at the given offset in the buffer.
+     */
+    private void writeTimeStamp(byte[] buffer, int offset, long time) {
+        // Special case: zero means zero.
+        if (time == 0) {
+            Arrays.fill(buffer, offset, offset + 8, (byte) 0x00);
+            return;
+        }
+
+        long seconds = time / 1000L;
+        long milliseconds = time - seconds * 1000L;
+        seconds += OFFSET_1900_TO_1970;
+
+        // write seconds in big endian format
+        buffer[offset++] = (byte)(seconds >> 24);
+        buffer[offset++] = (byte)(seconds >> 16);
+        buffer[offset++] = (byte)(seconds >> 8);
+        buffer[offset++] = (byte)(seconds >> 0);
+
+        long fraction = milliseconds * 0x100000000L / 1000L;
+        // write fraction in big endian format
+        buffer[offset++] = (byte)(fraction >> 24);
+        buffer[offset++] = (byte)(fraction >> 16);
+        buffer[offset++] = (byte)(fraction >> 8);
+        // low order bits should be random data
+        buffer[offset++] = (byte)(Math.random() * 255.0);
+    }
+}


### PR DESCRIPTION
This PR includes a new `NTPSyncedSensorRecordingService`, which uses a new `TimeProvider` that syncs the system time with an NTP server. The visibility of the `gracefullyStop` method from the `SensorRecordingService` was also changed to ease its extension.