### PR TITLE
Service notification vibration

### DIFF
--- a/backgroundsensors/build.gradle
+++ b/backgroundsensors/build.gradle
@@ -43,7 +43,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'io.github.geotecinit'
             artifactId = 'background-sensors'
-            version = '1.1.0'
+            version = '1.2.0'
 
             afterEvaluate {
                 from components.release
@@ -81,7 +81,7 @@ publishing {
         debug(MavenPublication) {
             groupId = 'io.github.geotecinit'
             artifactId = 'background-sensors'
-            version = '1.1.0-debug'
+            version = '1.2.0-debug'
 
             afterEvaluate {
                 from components.debug

--- a/backgroundsensors/src/main/java/es/uji/geotec/backgroundsensors/service/SensorRecordingService.java
+++ b/backgroundsensors/src/main/java/es/uji/geotec/backgroundsensors/service/SensorRecordingService.java
@@ -42,6 +42,7 @@ public abstract class SensorRecordingService extends Service {
         return binder;
     }
 
+    public static boolean vibrateOnStart = true;
     private static final String TAG = "SensorRecordingService";
 
     private static final int TIMEOUT = 1000 * 60;
@@ -93,7 +94,7 @@ public abstract class SensorRecordingService extends Service {
         NotificationProvider notificationProvider = new NotificationProvider(this);
 
         int notificationId = notificationProvider.getRecordingServiceNotificationId();
-        Notification notification = notificationProvider.getNotificationForRecordingService();
+        Notification notification = notificationProvider.getNotificationForRecordingService(vibrateOnStart);
 
         startForeground(notificationId, notification);
     }


### PR DESCRIPTION
This PR includes the required changes to enable or disable the notification vibration triggered when the data collection service starts. It also forces the foreground notification of the service to be shown in Android 12+.

**IMPORTANT**: The vibration can only be enabled/disabled on the **first** app start (i.e., it's not a configurable runtime feature)