### PR TITLE
Bump to Android 13 (api level 33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ To install the library you have to add the dependency in your `build.gradle`:
 
 ```groovy
 dependencies {
-    implementation 'io.github.geotecinit:background-sensors:1.2.0'
+    implementation 'io.github.geotecinit:background-sensors:1.3.0'
 }
 ```
 
-> **Note**: if you are considering to create a new library extending the features of 
+> [!TIP]
+> If you are considering to create a new library extending the features of 
 > background-sensors, use `api` instead of `implementation`. If you are extending the library
 > directly in an application, `implementation` should work.
 
@@ -87,11 +88,14 @@ public class Demo extends Activity {
 }
 ```
 
-> **Note**: a full example can be found in [DemoActivity](app/src/main/java/es/uji/geotec/backgroundsensorsdemo/DemoActivity.java)
+> [!TIP] 
+> A full example can be found in [DemoActivity](app/src/main/java/es/uji/geotec/backgroundsensorsdemo/DemoActivity.java)
 
 As the library uses a foreground service for the data collection, a notification is shown while the service
-is working. The notification has some default texts and icons, but you can override these settings.
+is working. Starting from Android 13 onwards, the notification will not be show unless the `POST_NOTIFICATION`
+permission is requested. You can do so by calling the `serviceManager.enableServiceNotification()` method.
 
+The notification has some default texts and icons, but you can override these settings.
 To change the notification's texts add these strings to your `strings.xml` with the desired values:
 
 ```xml
@@ -163,12 +167,14 @@ Specific record for the samples obtained from triaxial sensors (i.e., accelerome
 
 ### [`ServiceManager`](backgroundsensors/src/main/java/es/uji/geotec/backgroundsensors/service/manager/ServiceManager.java)
 
-| **Method**                                                                 | **Return type** | **Description**                                                       |
-|----------------------------------------------------------------------------|-----------------|-----------------------------------------------------------------------|
-| `startCollection(CollectionConfiguration config, RecordCallback callback)` | `void`          | Starts data collection for the sensor specified in the configuration. |
-| `stopCollection(Sensor sensor)`                                            | `void`          | Stops data collection for the specified sensor.                       |
+| **Method**                                                                 | **Return type** | **Description**                                                                                   |
+|----------------------------------------------------------------------------|-----------------|---------------------------------------------------------------------------------------------------|
+| `enableServiceNotification`                                                | `void`          | Requests permission POST_NOTIFICATION to show the collection service notification in Android 13+. |
+| `startCollection(CollectionConfiguration config, RecordCallback callback)` | `void`          | Starts data collection for the sensor specified in the configuration.                             |
+| `stopCollection(Sensor sensor)`                                            | `void`          | Stops data collection for the specified sensor.                                                   |
 
-> **Note**: the collection on a specific sensor can only be started **once**. This means that
+> [!IMPORTANT]
+> The collection on a specific sensor can only be started **once**. This means that
 > if you want to change the `sensorDelay` or the `batchSize` for a sensor that is already being 
 > collected, you must stop the collection first and then start it again with the new configuration. 
 
@@ -207,7 +213,8 @@ In that case, he/she can create its own `TimeProvider`.
 For an example implementation you can refer to [`BaseCollectorManager`](backgroundsensors/src/main/java/es/uji/geotec/backgroundsensors/collection/BaseCollectorManager.java).
 
 
-> **Note**: the developer is in charge of requesting the required permissions for the new sources,
+> [!NOTE] 
+> The developer is in charge of requesting the required permissions for the new sources,
 > in case they are needed.
 
 
@@ -217,4 +224,15 @@ Apache License 2.0
 
 See [LICENSE](LICENSE).
 
+
+## Author
+
+<a href="https://github.com/matey97" title="Miguel Matey Sanz">
+  <img src="https://avatars3.githubusercontent.com/u/25453537?s=120" alt="Miguel Matey Sanz" width="120"/>
+</a>
+
+
+## Acknowledgements
+
+The development of this library has been possible thanks to the Spanish Ministry of Universities (grant FPU19/05352).
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,11 +30,11 @@ android {
 
 dependencies {
 
-    implementation 'androidx.appcompat:appcompat:1.4.2'
-    implementation 'com.google.android.material:material:1.6.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.9.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation project(path: ':backgroundsensors')
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,12 +3,12 @@ plugins {
 }
 
 android {
-    compileSdk 31
+    compileSdk 33
 
     defaultConfig {
         applicationId "es.uji.geotec.backgroundsensors"
         minSdk 24
-        targetSdk 31
+        targetSdk 33
         versionCode 1
         versionName "1.0"
 
@@ -25,6 +25,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    namespace 'es.uji.geotec.backgroundsensorsdemo'
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="es.uji.geotec.backgroundsensorsdemo">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/es/uji/geotec/backgroundsensorsdemo/DemoActivity.java
+++ b/app/src/main/java/es/uji/geotec/backgroundsensorsdemo/DemoActivity.java
@@ -2,6 +2,7 @@ package es.uji.geotec.backgroundsensorsdemo;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
@@ -33,6 +34,10 @@ public class DemoActivity extends AppCompatActivity {
 
         sensorManager = new SensorManager(this);
         serviceManager = new ServiceManager(this, BaseSensorRecordingService.class);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            serviceManager.enableServiceNotification();
+        }
 
         sensorSpinner = findViewById(R.id.sensors_spinner);
         List<Sensor> sensors = sensorManager.availableSensors(BaseSensor.values());

--- a/backgroundsensors/build.gradle
+++ b/backgroundsensors/build.gradle
@@ -111,8 +111,8 @@ tasks.withType(Sign) {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/backgroundsensors/build.gradle
+++ b/backgroundsensors/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdk 31
+    compileSdk 33
 
     defaultConfig {
         minSdk 21
-        targetSdk 31
+        targetSdk 33
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -36,6 +36,7 @@ android {
             withSourcesJar()
         }
     }
+    namespace 'es.uji.geotec.backgroundsensors'
 }
 
 version = '1.2.0'

--- a/backgroundsensors/build.gradle
+++ b/backgroundsensors/build.gradle
@@ -39,7 +39,7 @@ android {
     namespace 'es.uji.geotec.backgroundsensors'
 }
 
-version = '1.2.0'
+version = '1.3.0'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 publishing {

--- a/backgroundsensors/src/main/AndroidManifest.xml
+++ b/backgroundsensors/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="es.uji.geotec.backgroundsensors">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />

--- a/backgroundsensors/src/main/AndroidManifest.xml
+++ b/backgroundsensors/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application>
         <service android:name=".service.BaseSensorRecordingService" android:exported="true" />

--- a/backgroundsensors/src/main/java/es/uji/geotec/backgroundsensors/service/manager/ServiceManager.java
+++ b/backgroundsensors/src/main/java/es/uji/geotec/backgroundsensors/service/manager/ServiceManager.java
@@ -1,11 +1,17 @@
 package es.uji.geotec.backgroundsensors.service.manager;
 
+import android.Manifest;
+import android.app.Activity;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
+import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.IBinder;
+
+import androidx.annotation.RequiresApi;
+import androidx.core.app.ActivityCompat;
 
 import es.uji.geotec.backgroundsensors.collection.CollectionConfiguration;
 import es.uji.geotec.backgroundsensors.record.callback.RecordCallback;
@@ -20,6 +26,20 @@ public class ServiceManager {
     public ServiceManager(Context context, Class<?> service) {
         this.context = context;
         this.service = service;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.TIRAMISU)
+    public void enableServiceNotification() {
+        int result = ActivityCompat.checkSelfPermission(this.context, Manifest.permission.POST_NOTIFICATIONS);
+        if (result == PackageManager.PERMISSION_GRANTED) {
+            return;
+        }
+
+        ActivityCompat.requestPermissions(
+                (Activity) this.context,
+                new String[]{Manifest.permission.POST_NOTIFICATIONS},
+                53
+        );
     }
 
     public void startCollection(CollectionConfiguration configuration, RecordCallback recordCallback) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.1.2' apply false
-    id 'com.android.library' version '7.1.2' apply false
+    id 'com.android.application' version '7.4.2' apply false
+    id 'com.android.library' version '7.4.2' apply false
 }
 
 task clean(type: Delete) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Jul 25 12:12:04 CEST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This PR includes the changes to compile the library targeting Android 13 (API level 33). 

The most remarkable change is the addition of the `POST_NOTIFICATIONS` permission to display the foreground service notification in apps running on Android 13. The permission can be requested using `serviceManager.enableServiceNotification()`.

Other changes:
- Update dependencies
- README: Update markdown alerts to the new syntax and add author and acknowledgements information. 