### PR TITLE
Bump to Android 14 (api level 34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To install the library you have to add the dependency in your `build.gradle`:
 
 ```groovy
 dependencies {
-    implementation 'io.github.geotecinit:background-sensors:1.3.0'
+    implementation 'io.github.geotecinit:background-sensors:1.4.0'
 }
 ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,12 +3,12 @@ plugins {
 }
 
 android {
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "es.uji.geotec.backgroundsensors"
         minSdk 24
-        targetSdk 33
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 

--- a/backgroundsensors/build.gradle
+++ b/backgroundsensors/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 21
-        targetSdk 33
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/backgroundsensors/build.gradle
+++ b/backgroundsensors/build.gradle
@@ -39,7 +39,7 @@ android {
     namespace 'es.uji.geotec.backgroundsensors'
 }
 
-version = '1.3.0'
+version = '1.4.0'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 publishing {

--- a/backgroundsensors/src/main/AndroidManifest.xml
+++ b/backgroundsensors/src/main/AndroidManifest.xml
@@ -5,9 +5,21 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
 
     <application>
-        <service android:name=".service.BaseSensorRecordingService" android:exported="true" />
-        <service android:name=".service.NTPSyncedSensorRecordingService" android:exported="true" />
+        <service android:name=".service.BaseSensorRecordingService"
+            android:foregroundServiceType="specialUse"
+            android:exported="true">
+            <property android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Foreground service for handling data collection from sensors."/>
+        </service>
+
+        <service android:name=".service.NTPSyncedSensorRecordingService"
+            android:foregroundServiceType="specialUse"
+            android:exported="true">
+            <property android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Foreground service for handling data collection from sensors with NTP syncing."/>
+        </service>
     </application>
 </manifest>


### PR DESCRIPTION
This PR includes adds support to run the library on Android 14 devices. More concretely, as mentioned in #9, the library declares in the manifest the `foregroundServiceType` for the data collection services. The `foregroundServiceType` has been set to `specialUse` since no other types completely match the intended use.